### PR TITLE
Fixed bug when converting negative zero to string.

### DIFF
--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -36,7 +36,7 @@ impl Buffer {
         #[cfg(maybe_uninit)]
         let bytes = [MaybeUninit::<u8>::uninit(); 25];
         #[cfg(not(maybe_uninit))]
-        let bytes = unsafe { mem::uninitialized() };
+        let bytes = unsafe { core::mem::uninitialized() };
 
         Buffer { bytes }
     }

--- a/src/pretty/mod.rs
+++ b/src/pretty/mod.rs
@@ -57,7 +57,7 @@ pub unsafe fn format64(f: f64, result: *mut u8) -> usize {
         (bits >> DOUBLE_MANTISSA_BITS) as u32 & ((1u32 << DOUBLE_EXPONENT_BITS) - 1);
 
     if ieee_exponent == 0 && ieee_mantissa == 0 {
-        ptr::copy_nonoverlapping(b"0".as_ptr(), result, 1);
+        *result = b'0';
         return 1;
     }
 
@@ -98,12 +98,12 @@ pub unsafe fn format64(f: f64, result: *mut u8) -> usize {
         write_mantissa_long(v.mantissa, result.offset(index + length + offset));
         index as usize + length as usize + offset as usize
     } else if length == 1 {
-        // 1e30
+        // 1e+30
         *result.offset(index) = b'0' + v.mantissa as u8;
         *result.offset(index + 1) = b'e';
         index as usize + 2 + write_exponent3(kk - 1, result.offset(index + 2))
     } else {
-        // 1234e30 -> 1.234e33
+        // 1234e30 -> 1.234e+33
         write_mantissa_long(v.mantissa, result.offset(index + length + 1));
         *result.offset(index) = *result.offset(index + 1);
         *result.offset(index + 1) = b'.';

--- a/src/pretty/mod.rs
+++ b/src/pretty/mod.rs
@@ -56,15 +56,15 @@ pub unsafe fn format64(f: f64, result: *mut u8) -> usize {
     let ieee_exponent =
         (bits >> DOUBLE_MANTISSA_BITS) as u32 & ((1u32 << DOUBLE_EXPONENT_BITS) - 1);
 
+    if ieee_exponent == 0 && ieee_mantissa == 0 {
+        ptr::copy_nonoverlapping(b"0".as_ptr(), result, 1);
+        return 1;
+    }
+
     let mut index = 0isize;
     if sign {
         *result = b'-';
         index += 1;
-    }
-
-    if ieee_exponent == 0 && ieee_mantissa == 0 {
-        ptr::copy_nonoverlapping(b"0".as_ptr(), result.offset(index), 1);
-        return sign as usize + 1;
     }
 
     let v = d2d(ieee_mantissa, ieee_exponent);
@@ -116,6 +116,8 @@ pub unsafe fn format64(f: f64, result: *mut u8) -> usize {
 }
 
 /// Print f32 to the given buffer and return number of bytes written.
+///
+/// **NOTE:** This is not ECMASCript complaint.
 ///
 /// At most 16 bytes will be written.
 ///

--- a/tests/d2s_test.rs
+++ b/tests/d2s_test.rs
@@ -226,6 +226,9 @@ fn test_ecma262_compliance() {
     assert_eq!(pretty(f64::NEG_INFINITY), "-Infinity");
     assert_eq!(pretty(0.0), "0");
     assert_eq!(pretty(9.0), "9");
+    assert_eq!(pretty(90.0), "90");
+    assert_eq!(pretty(90.12), "90.12");
+
     assert_eq!(pretty(0.000001), "0.000001");
     assert_eq!(pretty(0.0000001), "1e-7");
     assert_eq!(pretty(3e50), "3e+50");
@@ -237,16 +240,28 @@ fn test_ecma262_compliance() {
     assert_eq!(pretty(11111111111111111111111.0), "1.1111111111111111e+22");
 
     assert_eq!(pretty(0.1), "0.1");
+    assert_eq!(pretty(0.01), "0.01");
+    assert_eq!(pretty(0.001), "0.001");
+    assert_eq!(pretty(0.0001), "0.0001");
+    assert_eq!(pretty(0.00001), "0.00001");
+    assert_eq!(pretty(0.000001), "0.000001");
     assert_eq!(pretty(0.0000001), "1e-7");
     assert_eq!(pretty(0.00000012), "1.2e-7");
     assert_eq!(pretty(0.000000123), "1.23e-7");
     assert_eq!(pretty(0.00000001), "1e-8");
 
+    assert_eq!(pretty(-0.0), "0");
     assert_eq!(pretty(-9.0), "-9");
     assert_eq!(pretty(-90.12), "-90.12");
+    assert_eq!(pretty(-0.0000000123), "-1.23e-8");
     assert_eq!(pretty(-111111111111111111111.0), "-111111111111111110000");
     assert_eq!(pretty(-1111111111111111111111.0), "-1.1111111111111111e+21");
     assert_eq!(pretty(-0.000000123), "-1.23e-7");
+
+    assert_eq!(
+        pretty(123456789010111213141516171819.0),
+        "1.234567890101112e+29"
+    );
 }
 
 #[test]


### PR DESCRIPTION
This PR fixes, converting a negative zero `-0.0` to string. previously we would give `"-0"` as the converted string and this is wrong according to spec step 2 in <https://tc39.es/ecma262/#sec-numeric-types-number-tostring>
> If x is +0 or -0, return the String "0".

 - Made zero number printing more efficient because we don't use unnecessary `ptr::copy_nonoverlapping`, instead we directly put the 0 in the buffer
 - Fixed compatibility with rust `1.31.0`

Also added some more ECMAScript compliance tests and a **NOTE** to `format32` because it is not spec compliant.