### PR TITLE
Fix max length of format functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ryu-js"
 version = "0.1.0" # don't forget to update html_root_url
-authors = ["David Tolnay <dtolnay@gmail.com>"]
+authors = ["David Tolnay <dtolnay@gmail.com>", "boa-dev"]
 license = "Apache-2.0 OR BSL-1.0"
 description = "Fast floating point to string conversion, ECMAScript compliant."
 repository = "https://github.com/boa-dev/ryu-js"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Ryū-js
 
 Ryū-js is a fork of the [ryu][ryu-crate] crate adjusted to comply to the ECMAScript [number-to-string][number-to-string] algorithm.
-This crate is used in the `Boa` crate for number to string conversions
+This crate is used in the [boa][boa-crate] for number to string conversions.
 
 [ryu-crate]: https://crates.io/crates/ryu
+[boa-crate]: https://crates.io/crates/Boa
 [number-to-string]: https://tc39.es/ecma262/#sec-numeric-types-number-tostring
 
 Pure Rust implementation of Ryū, an algorithm to quickly convert floating point

--- a/src/pretty/mod.rs
+++ b/src/pretty/mod.rs
@@ -40,7 +40,7 @@ use no_panic::no_panic;
 /// let f = 1.234f64;
 ///
 /// unsafe {
-///     let mut buffer = [MaybeUninit::<u8>::uninit(); 24];
+///     let mut buffer = [MaybeUninit::<u8>::uninit(); 25];
 ///     let len = ryu_js::raw::format64(f, buffer.as_mut_ptr() as *mut u8);
 ///     let slice = slice::from_raw_parts(buffer.as_ptr() as *const u8, len);
 ///     let print = str::from_utf8_unchecked(slice);

--- a/src/pretty/mod.rs
+++ b/src/pretty/mod.rs
@@ -117,7 +117,7 @@ pub unsafe fn format64(f: f64, result: *mut u8) -> usize {
 
 /// Print f32 to the given buffer and return number of bytes written.
 ///
-/// At most 16 bytes will be written.
+/// At most 22 bytes will be written.
 ///
 /// ## Special cases
 ///
@@ -145,7 +145,7 @@ pub unsafe fn format64(f: f64, result: *mut u8) -> usize {
 /// let f = 1.234f32;
 ///
 /// unsafe {
-///     let mut buffer = [MaybeUninit::<u8>::uninit(); 16];
+///     let mut buffer = [MaybeUninit::<u8>::uninit(); 22];
 ///     let len = ryu_js::raw::format32(f, buffer.as_mut_ptr() as *mut u8);
 ///     let slice = slice::from_raw_parts(buffer.as_ptr() as *const u8, len);
 ///     let print = str::from_utf8_unchecked(slice);


### PR DESCRIPTION
This PR changes:
 - Fixed doc example of `format64`
 - Added `boa-dev` organization to authors.
 - Fixed max length in `format32`  (this was done by brute forcing all possible f32) which is 22 bytes.