### PR TITLE
Added `CHANGELOG.md` and version bump `v0.2.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-# [# 0.2.0 (2020-07-14) - ECMAScript complaint `f32` conversions Release](https://github.com/boa-dev/ryu-js/compare/v0.1.0...v0.2.0)
+# [# 0.2.0 (2020-07-14) - ECMAScript compliant `f32` conversions Release](https://github.com/boa-dev/ryu-js/compare/v0.1.0...v0.2.0)
 
 Feature enhancements:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# CHANGELOG
+
+# [# 0.2.0 (2020-07-14) - ECMAScript complaint `f32` conversions Release](https://github.com/boa-dev/ryu-js/compare/v0.1.0...v0.2.0)
+
+Feature enhancements:
+
+ - [FEATURE #6](https://github.com/boa-dev/ryu-js/pull/6):
+  ECMAScript specification complaint `f32` to string conversions. (@HalidOdat)
+
+Bug fixes:
+
+ - [BUG #2](https://github.com/boa-dev/ryu-js/pull/2):
+  Fixed Comatibility with rust `1.31.0`. (@HalidOdat)
+ - [BUG #2](https://github.com/boa-dev/ryu-js/pull/2):
+  Fixed converting from `-0.0` to `0`. (@HalidOdat)
+ - [BUG #2](https://github.com/boa-dev/ryu-js/pull/2):
+  Fixed max length docs for `format32` and `format64`. (@HalidOdat)
+
+Internal improvements:
+
+ - [INTERNAL #2](https://github.com/boa-dev/ryu-js/pull/2):
+  Optimized `0` and `-0` to string conversion (@HalidOdat)
+
+# [0.1.0 (2020-07-13) - ECMAScript complaint `f64` conversions Release](https://github.com/boa-dev/ryu-js/compare/v0.0.0...v0.1.0)
+
+This is the initial release of this crate, it introduces ECMAScript compliant `f64` to string conversions.
+
+Feature enhancements:
+
+- [FEATURE](https://github.com/boa-dev/ryu-js/commit/ed781f5772882e38c53d40707a60b4f11414b9c8):
+  ECMAScript specification complaint `f64` to string conversions. (@Tropid)
+- [FEATURE](https://github.com/boa-dev/ryu-js/commit/fe366fa397d04324fa693b5d85134851b09719b3):
+  Change name from `ryu` to `ryu-js`. (@Tropid)
+
+Bug fixes:
+
+- [BUG #1](https://github.com/boa-dev/ryu-js/pull/1):
+  Fixed buffer overflow with length greater than 24 (max is 25). (@HalidOdat)
+
+Internal improvements:
+
+ - [INTERNAL #1](https://github.com/boa-dev/ryu-js/pull/2):
+  Fixed all clippy warnings/errors and tests (@HalidOdat)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,10 @@ Feature enhancements:
 
 Bug fixes:
 
- - [BUG #2](https://github.com/boa-dev/ryu-js/pull/2):
-  Fixed Comatibility with rust `1.31.0`. (@HalidOdat)
- - [BUG #2](https://github.com/boa-dev/ryu-js/pull/2):
-  Fixed converting from `-0.0` to `0`. (@HalidOdat)
- - [BUG #2](https://github.com/boa-dev/ryu-js/pull/2):
-  Fixed max length docs for `format32` and `format64`. (@HalidOdat)
+ - [BUG #2](https://github.com/boa-dev/ryu-js/pull/2) (@HalidOdat):
+   - Fixed Comatibility with rust `1.31.0`.
+   - Fixed converting from `-0.0` to `0`.
+   - Fixed max length docs for `format32` and `format64`.
 
 Internal improvements:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Internal improvements:
  - [INTERNAL #2](https://github.com/boa-dev/ryu-js/pull/2):
   Optimized `0` and `-0` to string conversion (@HalidOdat)
 
-# 0.1.0 (2020-07-13) - ECMAScript complaint `f64` conversions Release
+# 0.1.0 (2020-07-13) - ECMAScript compliant `f64` conversions Release
 
 This is the initial release of this crate, it introduces ECMAScript compliant `f64` to string conversions.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Internal improvements:
  - [INTERNAL #2](https://github.com/boa-dev/ryu-js/pull/2):
   Optimized `0` and `-0` to string conversion (@HalidOdat)
 
-# [0.1.0 (2020-07-13) - ECMAScript complaint `f64` conversions Release](https://github.com/boa-dev/ryu-js/compare/v0.0.0...v0.1.0)
+# 0.1.0 (2020-07-13) - ECMAScript complaint `f64` conversions Release
 
 This is the initial release of this crate, it introduces ECMAScript compliant `f64` to string conversions.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Feature enhancements:
 Bug fixes:
 
  - [BUG #2](https://github.com/boa-dev/ryu-js/pull/2) (@HalidOdat):
-   - Fixed Comatibility with rust `1.31.0`.
+   - Fixed compatibility with rust `1.31.0`.
    - Fixed converting from `-0.0` to `0`.
    - Fixed max length docs for `format32` and `format64`.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryu-js"
-version = "0.1.0" # don't forget to update html_root_url
+version = "0.2.0" # don't forget to update html_root_url
 authors = ["David Tolnay <dtolnay@gmail.com>", "boa-dev"]
 license = "Apache-2.0 OR BSL-1.0"
 description = "Fast floating point to string conversion, ECMAScript compliant."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 //! notation.
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/ryu-js/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/ryu-js/0.2.0")]
 #![cfg_attr(feature = "cargo-clippy", allow(renamed_and_removed_lints))]
 #![cfg_attr(
     feature = "cargo-clippy",


### PR DESCRIPTION
 - Added changelog for `ryu-js`
 - bump version from `0.1.0` to `0.2.0`

I made the jump from `0.1.0` to `0.2.0` because it is not just a patch, this version introduces ECMAScript compliant `f32` to string conversions, like `v0.1.0` introduced `f64` conversions.

I don't like the way `bug #2` is repeated so many times but I also want to say what has been fixed, should I compact it into one bug fix?