### PR TITLE
Revert "Bump dtolnay/rust-toolchain from 1.36.0 to 1.70.0"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.70.0
+      - uses: dtolnay/rust-toolchain@1.36.0
       - run: cargo build
       - run: cargo build --features small
 


### PR DESCRIPTION
Reverts boa-dev/ryu-js#23