### PR TITLE
Mark d2d function as unsafe

### DIFF
--- a/src/d2s.rs
+++ b/src/d2s.rs
@@ -86,7 +86,7 @@ pub struct FloatingDecimal64 {
 }
 
 #[cfg_attr(feature = "no-panic", inline)]
-pub fn d2d(ieee_mantissa: u64, ieee_exponent: u32) -> FloatingDecimal64 {
+pub unsafe fn d2d(ieee_mantissa: u64, ieee_exponent: u32) -> FloatingDecimal64 {
     let (e2, m2) = if ieee_exponent == 0 {
         (
             // We subtract 2 so that the bounds computation has 2 additional bits.

--- a/src/pretty/mod.rs
+++ b/src/pretty/mod.rs
@@ -68,7 +68,7 @@ pub unsafe fn format64(f: f64, result: *mut u8) -> usize {
         index += 1;
     }
 
-    let v = d2d(ieee_mantissa, ieee_exponent);
+    let v = unsafe { d2d(ieee_mantissa, ieee_exponent) };
 
     let length = d2s::decimal_length17(v.mantissa) as isize;
     let k = v.exponent as isize;


### PR DESCRIPTION
<!---
Thank you for contributing to ryu-js! Please fill out the template below, and remove or add any information as you feel necessary.
--->

This Pull Request fixes/closes #{issue_num}.

It changes the following:

-
-
-
https://github.com/boa-dev/ryu-js/blob/c15c2084de37ebd9f353218bfb7792c4d8416ee3/src/d2s.rs#L89-L300
@jasonwilliams Hello, in the above test case, the function has a ’attempt to subtract with overflow’ panicked.
```rust
    let _ = d2d(0, 0);
``` 
`thread 'main' panicked at 'attempt to subtract with overflow' `
This function should be marked as unsafe, or subtract using wrapping_sub()