### PR TITLE
Release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## [# 1.0.1 (2024-03-02)](https://github.com/boa-dev/ryu-js/compare/v1.0.0...v1.0.1)
+
+### Internal Improvements
+
+- [INTERNAL #45](https://github.com/boa-dev/ryu-js/pull/45): Add release workflow. (@HalidOdat)
+- [INTERNAL #43](https://github.com/boa-dev/ryu-js/pull/43): Add `#[inline]` to public functions. (@HalidOdat)
+- [INTERNAL #42](https://github.com/boa-dev/ryu-js/pull/42): Sync upstream/master. (@HalidOdat, @jedel1043)
+
 ## [# 1.0.0 (2023-10-05)](https://github.com/boa-dev/ryu-js/compare/v0.2.2...v1.0.0) - ECMAScript compliant implementation of `Number.prototype.toFixed()`
 
 ### Breaking Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryu-js"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["David Tolnay <dtolnay@gmail.com>", "boa-dev"]
 categories = ["value-formatting", "no-std", "no-std::no-alloc"]
 description = "Fast floating point to string conversion, ECMAScript compliant."


### PR DESCRIPTION
It changes the following:

- Update changelog
- Bump version from `v1.0.0` to `v1.0.1`
